### PR TITLE
ajout retirer argent 

### DIFF
--- a/src/myPackage/CompteCourant.java
+++ b/src/myPackage/CompteCourant.java
@@ -10,6 +10,16 @@ public class CompteCourant extends CompteBancaire {
 		public void deposerC(double valeur) {
 	        setSolde(getSolde()+valeur);
 	    }
+		
+		public void retirerC(double valeur) throws Exception {
+			if (valeur > getSolde()) {
+				throw new Exception("Insufficient funds");
+			}
+			setSolde(getSolde() - valeur);
+		
+
+			
+		}
 
 
 	    

--- a/src/myPackage/DossierBancaire.java
+++ b/src/myPackage/DossierBancaire.java
@@ -27,6 +27,10 @@ public class DossierBancaire {
     	ep.renumererE();
     	
     }
+    public void retirer(double valeur)throws Exception {
+    	cc.retirerC(valeur);
+    }
+    
 	
     
 }

--- a/src/tests/TestsDossierBancaire.java
+++ b/src/tests/TestsDossierBancaire.java
@@ -33,6 +33,24 @@ public class TestsDossierBancaire {
 			System.out.println(dossier.get_solde());
 			assertEquals(solde_expected,dossier.get_solde(),0.001); //voir documentation en ligne sur assertions Junit 
 		}
+	 
+	 @Test
+		public void testRetirerSuccess() throws Exception {
+		 DossierBancaire dossier=new DossierBancaire();
+			dossier.deposer(50);
+			dossier.retirer(50*0.4);
+			assertEquals(30, dossier.get_solde(), 0.00);
+			
+			
+		}
+	 @Test
+		public void testRetirerInsufficientFunds() throws Exception {
+		 DossierBancaire dossier=new DossierBancaire();	
+			dossier.retirer(200);
+			Exception exception = assertThrows(Exception.class, () -> dossier.retirer(200));
+			assertEquals("Insufficient funds", exception.getMessage());
+		
+		}
 	
 
 }


### PR DESCRIPTION
1. Ajoutez la possibilité de retirer de l’argent du dossier bancaire :on considérera qu’un tel retrait n’altère que la classe «Compte Courant», et qu’une exception est levée si le solde est insuffisant.
2. Faites en sorte que la levée de cette exception soit vérifiée par le test unitaire associée